### PR TITLE
Adding `blocking?` option on creation

### DIFF
--- a/src/com/moclojer/components/core.clj
+++ b/src/com/moclojer/components/core.clj
@@ -30,11 +30,12 @@
 (def setup-logger logs/setup)
 
 (defn new-mq
-  ([workers]
-   (new-mq workers []))
-  ([workers jobs]
+  ([workers blocking?]
+   (new-mq workers [] blocking?))
+  ([workers jobs blocking?]
    (mq/map->MQ {:workers workers
-                :jobs jobs})))
+                :jobs jobs
+                :blocking? blocking?})))
 
 (defn new-mq-mock
   []

--- a/src/com/moclojer/components/mq.clj
+++ b/src/com/moclojer/components/mq.clj
@@ -102,7 +102,7 @@
               (Thread/sleep sleep)
               (recur (inc attempt)))))))))
 
-(defonce mock-channels (atom {}))
+(def mock-channels (atom {}))
 
 (defn mock-op-name->op-fn
   "Adapts given mq `operation name` to its relative function."

--- a/test/com/moclojer/components/mq_test.clj
+++ b/test/com/moclojer/components/mq_test.clj
@@ -39,7 +39,8 @@
     :mq (component/using (components/new-mq [{:handler fake-worker
                                               :channel "test"}
                                              {:handler job-worker
-                                              :channel "test-job"}])
+                                              :channel "test-job"}]
+                                            false)
                          [:config :database :storage :sentry])
     :storage (component/using (components/new-storage) [:config]))))
 


### PR DESCRIPTION
closes #4

- **feat: add `blocking?` option on creation**
- **fix: add missing blocking param**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced configuration options for the message queue function with an additional `blocking?` parameter.

- **Refactor**
  - Changed initialization method for `mock-channels` to improve management and usage.

- **Tests**
  - Updated test configurations to align with new function parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->