### PR TITLE
Use real config path on record instead of `cfg`

### DIFF
--- a/src/com/moclojer/components/logs.clj
+++ b/src/com/moclojer/components/logs.clj
@@ -73,10 +73,10 @@
 ;; If on dev `env`, does basically nothing besides setting the min
 ;; level. On `prod` env however, an async channel waits for log events,
 ;; which are then sent to OpenSearch.
-(defrecord Logger [cfg]
+(defrecord Logger [config]
   component/Lifecycle
   (start [this]
-    (let [config (:config cfg)
+    (let [config (:config config)
           prod? (= (:env config) :prod)
           os-cfg (:opensearch config)
           log-ch (async/chan)


### PR DESCRIPTION
fixes #12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the parameter name from `cfg` to `config` in the Logger record for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->